### PR TITLE
feat: :shirt: adiciona allow-leading-underscore

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -71,7 +71,7 @@
       ]
     },
     "variable-name": {
-      "options": ["ban-keywords", "check-format", "allow-pascal-case"]
+      "options": ["ban-keywords", "check-format", "allow-pascal-case", "allow-leading-underscore"]
     },
     "whitespace": {
       "options": [


### PR DESCRIPTION
Adicionando allow-leading-underscore no tslint.json do workspace, com o objetivo de eliminar o alerta referente ao sublinhado no início de uma propriedade emitido pelo tslint.